### PR TITLE
Update a few links

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,10 @@ Good features realization.
 * [SlickGrid](https://github.com/mleibman/SlickGrid) - Many features. There is even an infinite feature (1 000 000 rows). Themes looks out of date. Product is well known. Last update in 2014!  
 * [Tablesorter](https://github.com/christianbach/tablesorter) - Small table plugin that enables sorting and several features.  Mainly used to enable fast sorting on html table.  
 
-### AngularJS
-* [Angular2 Grid](https://swimlane.gitbooks.io/ngx-datatable/) - Professional Angular2 Grid with basic features.
+### Angular
+* [ngx-datatable](https://swimlane.gitbooks.io/ngx-datatable/) - A feature-rich yet lightweight data-table crafted for Angular2 and beyond!
+
+## AngularJS
 * [ui-grid](http://ui-grid.info/) - Professional complete grid solution.
 
 ### React

--- a/README.md
+++ b/README.md
@@ -41,10 +41,8 @@ Good features realization.
 * [SlickGrid](https://github.com/mleibman/SlickGrid) - Many features. There is even an infinite feature (1 000 000 rows). Themes looks out of date. Product is well known. Last update in 2014!  
 * [Tablesorter](https://github.com/christianbach/tablesorter) - Small table plugin that enables sorting and several features.  Mainly used to enable fast sorting on html table.  
 
-### Angular
-* [ngx-datatable](https://swimlane.gitbooks.io/ngx-datatable/) - A feature-rich yet lightweight data-table crafted for Angular2 and beyond!
-
-## AngularJS
+### AngularJS
+* [ngx-datatable](https://swimlane.gitbooks.io/ngx-datatable/) - A feature-rich lightweight data-table crafted for Angular2.
 * [ui-grid](http://ui-grid.info/) - Professional complete grid solution.
 
 ### React


### PR DESCRIPTION
- Renamed `Angular2 Table` to correct name `ngx-datatable`
- Seperated `AngularJS` from `Angular` per library naming standards