### PR TITLE
Update DataTables to link to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ But it does not provide styling.
 
 ### jQuery
 * [appendGrid](http://appendgrid.apphb.com/) - The dynamic table input jQuery plugin. It has basic features. The design looks old.  
-* [DataTables](http://datatables.net/) - Easy to use library. It is the number one grid solution on jQuery.  
+* [DataTables](https://github.com/DataTables/DataTablesSrc) - Easy to use library. It is the number one grid solution on jQuery.  
 * [Dynatable](http://dynatable.com/) - It has basic features. Last update in 2014!  
 * [Frappe DataTable](https://frappe.io/datatable) - A simple, modern and interactive datatable library on es6. Current version is full of small bugs.  
 * [jExcel](https://github.com/paulhodel/jexcel) - jExcel is is a very light jquery plugin to embed a spreadsheet, compatible with Excel, in your browser. You can load data straight to a jExcel table from a JS array, json or even a CSV file.  


### PR DESCRIPTION
idk if this is actually desired, I just had a hard time looking for the source code from their website. Github link would have been more useful for me, especially since the github repo has a link to the website. Feel free to close the PR though if you disagree no harm done, a weak suggestion at best